### PR TITLE
FIX: Use the right command to build docs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - run: pip install mkdocs
 
       - name: Build docs site
-        run: mkdocs fosshack-handbook/mkdocs.yml
+        run: mkdocs build fosshack-handbook/mkdocs.yml
 
       - name: Deploy
         run: mkdocs gh-deploy


### PR DESCRIPTION
PR #1 introduced as mistake where the docs weren't being built using the correct command. This PR fixes that problem.